### PR TITLE
Allow caller to pick default entry mode

### DIFF
--- a/lib/src/field.dart
+++ b/lib/src/field.dart
@@ -24,6 +24,7 @@ typedef DateTimeFieldCreator = DateTimeField Function({
   DateTime? lastDate,
   DateTimeFieldPickerMode mode,
   bool use24hFormat,
+  TimePickerEntryMode initialTimePickerEntryMode,
 });
 
 /// [DateTimeField]
@@ -47,6 +48,7 @@ class DateTimeField extends StatelessWidget {
     DateTime? firstDate,
     DateTime? lastDate,
     DateFormat? dateFormat,
+    this.initialTimePickerEntryMode = TimePickerEntryMode.dial,
   })  : dateFormat = dateFormat ?? getDateFormatFromDateFieldPickerMode(mode),
         firstDate = firstDate ?? _kDefaultFirstSelectableDate,
         lastDate = lastDate ?? _kDefaultLastSelectableDate,
@@ -62,6 +64,7 @@ class DateTimeField extends StatelessWidget {
     this.dateTextStyle,
     this.use24hFormat = false,
     this.initialEntryMode = DatePickerEntryMode.calendar,
+    this.initialTimePickerEntryMode = TimePickerEntryMode.dial,
     DateTime? firstDate,
     DateTime? lastDate,
   })  : initialDatePickerMode = null,
@@ -109,6 +112,9 @@ class DateTimeField extends StatelessWidget {
 
   /// The initial entry mode for the material date picker dialog
   final DatePickerEntryMode initialEntryMode;
+
+  // the initial entry mode for the material time picker dialog
+  final TimePickerEntryMode initialTimePickerEntryMode;
 
   /// Shows a dialog asking the user to pick a date !
   Future<void> _selectDate(BuildContext context) async {
@@ -158,8 +164,9 @@ class DateTimeField extends StatelessWidget {
       ];
 
       if (modesWithTime.contains(mode)) {
-        final TimeOfDay? _selectedTime =
-            await showMaterialTimePicker(context, initialDateTime);
+        final TimeOfDay? _selectedTime = await showMaterialTimePicker(
+            context, initialDateTime,
+            initialEntryMode: initialTimePickerEntryMode);
 
         if (_selectedTime != null) {
           _selectedDateTime = DateTime(
@@ -179,12 +186,12 @@ class DateTimeField extends StatelessWidget {
   /// Launches the Material time picker by invoking [showTimePicker].
   /// Can be @[override]n to allow further customization of the picker options
   Future<TimeOfDay?> showMaterialTimePicker(
-    BuildContext context,
-    DateTime initialDateTime,
-  ) async {
+      BuildContext context, DateTime initialDateTime,
+      {TimePickerEntryMode initialEntryMode = TimePickerEntryMode.dial}) async {
     return showTimePicker(
       initialTime: TimeOfDay.fromDateTime(initialDateTime),
       context: context,
+      initialEntryMode: initialEntryMode,
       builder: (BuildContext context, Widget? child) {
         return MediaQuery(
           data: MediaQuery.of(context).copyWith(

--- a/lib/src/form_field.dart
+++ b/lib/src/form_field.dart
@@ -30,6 +30,7 @@ class DateTimeFormField extends FormField<DateTime> {
     DatePickerEntryMode initialEntryMode = DatePickerEntryMode.calendar,
     DatePickerMode initialDatePickerMode = DatePickerMode.day,
     DateTimeFieldPickerMode mode = DateTimeFieldPickerMode.dateAndTime,
+    TimePickerEntryMode initialTimePickerEntryMode = TimePickerEntryMode.dial,
     DateTimeFieldCreator fieldCreator = DateTimeField.new,
   }) : super(
           key: key,
@@ -68,6 +69,7 @@ class DateTimeFormField extends FormField<DateTime> {
               mode: mode,
               initialEntryMode: initialEntryMode,
               dateTextStyle: dateTextStyle,
+              initialTimePickerEntryMode: initialTimePickerEntryMode,
             );
           },
         );


### PR DESCRIPTION
Hello! This PR adds the ability to pick the initial state (touch or keyboard) of the time picker widget. We needed this for a better web experience. It might be worth to have the switching logic in this package, but for now it's nice to have the option to pick the initial state.

Thank you!