### PR TITLE
[5.0.0] removed deprecated parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0
+
+- Removed deprecated parameters 
+
 # 4.1.0
 
 - Adding better styling options for the iOS and MacOS modal sheet. It is now possible to specify the text style of the save and cancel buttons, as well as the title of the modal sheet. Solution to issue #59

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0
+
+- Removing deprecated parameters. Use `dart fix` to migrate.
+
 # 4.0.0
 
 - Removing override of MediaQuery.alwaysUse24HourFormat from the time picker dialog

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ parameter.
    ```yaml
    dependencies:
      ...
-     date_field: ^4.0.0
+     date_field: ^5.0.0
    ```
 2. Run `flutter pub get` to install the package.
 3. Initialize your systems locale. If not, users might see AM/PM even when

--- a/lib/src/field.dart
+++ b/lib/src/field.dart
@@ -48,73 +48,26 @@ class DateTimeField extends StatefulWidget {
   DateTimeField({
     required this.onChanged,
     super.key,
-    DateTime? value,
+    this.value,
     this.onTap,
-    TextStyle? style,
+    this.style,
     this.focusNode,
     this.autofocus = false,
     this.enableFeedback,
     this.padding,
     this.hideDefaultSuffixIcon = false,
     this.decoration,
-    DateTime? initialPickerDateTime,
+    this.initialPickerDateTime,
     this.cupertinoDatePickerOptions = const CupertinoDatePickerOptions(),
-    MaterialDatePickerOptions? materialDatePickerOptions,
-    MaterialTimePickerOptions? materialTimePickerOptions,
+    this.materialDatePickerOptions = const MaterialDatePickerOptions(),
+    this.materialTimePickerOptions = const MaterialTimePickerOptions(),
     this.mode = DateTimeFieldPickerMode.dateAndTime,
     DateTime? firstDate,
     DateTime? lastDate,
     DateFormat? dateFormat,
-    this.use24hFormat,
-    @Deprecated('''
-    enabled has no effect anymore. It gets evaluated from onChanged != null.
-    Will be removed in v5.0.0.
-    ''') bool? enabled,
-    @Deprecated('''
-    Use value instead.
-    Will be removed in v5.0.0.
-    ''') DateTime? selectedDate,
-    @Deprecated('''
-    Use style instead.
-    Will be removed in v5.0.0.
-    ''') TextStyle? dateTextStyle,
-    @Deprecated('''
-    Use onChanged instead.
-    Will be removed in v5.0.0.
-    ''') ValueChanged<DateTime>? onDateSelected,
-    @Deprecated('''
-    Use materialDatePickerOptions.initialDatePickerMode instead.
-    Will be removed in v5.0.0
-    ''') DatePickerMode? initialDatePickerMode,
-    @Deprecated('''
-    Use materialDatePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') DatePickerEntryMode? initialEntryMode,
-    @Deprecated('''
-    Use initialPickerDateTime instead.
-    Will be removed in v5.0.0
-    ''') DateTime? initialDate,
-    @Deprecated('''
-    Use materialTimePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') TimePickerEntryMode? initialTimePickerEntryMode,
-  })  : assert(enabled == null || enabled == (onChanged != null),
-            'enabled got deprecated. The new behavior uses `onChanged != null`'),
-        dateFormat = dateFormat ?? mode.toDateFormat(),
-        style = style ?? dateTextStyle,
+  })  : dateFormat = dateFormat ?? mode.toDateFormat(),
         firstDate = firstDate ?? _kDefaultFirstSelectableDate,
-        lastDate = lastDate ?? _kDefaultLastSelectableDate,
-        initialPickerDateTime = initialPickerDateTime ?? initialDate,
-        value = value ?? selectedDate,
-        materialDatePickerOptions = materialDatePickerOptions ??
-            MaterialDatePickerOptions(
-              initialEntryMode: initialEntryMode ?? DatePickerEntryMode.calendar,
-              initialDatePickerMode: initialDatePickerMode ?? DatePickerMode.day,
-            ),
-        materialTimePickerOptions = materialTimePickerOptions ??
-            MaterialTimePickerOptions(
-              initialEntryMode: initialTimePickerEntryMode ?? TimePickerEntryMode.dial,
-            );
+        lastDate = lastDate ?? _kDefaultLastSelectableDate;
 
   factory DateTimeField.time({
     Key? key,
@@ -126,7 +79,7 @@ class DateTimeField extends StatefulWidget {
     DateTime? initialPickerDateTime,
     TextStyle? style,
     CupertinoDatePickerOptions cupertinoDatePickerOptions = const CupertinoDatePickerOptions(),
-    MaterialTimePickerOptions? materialTimePickerOptions,
+    MaterialTimePickerOptions materialTimePickerOptions = const MaterialTimePickerOptions(),
     bool autofocus = false,
     DateFormat? dateFormat,
     EdgeInsetsGeometry? padding,
@@ -134,37 +87,6 @@ class DateTimeField extends StatefulWidget {
     FocusNode? focusNode,
     bool hideDefaultSuffixIcon = false,
     bool? enableFeedback,
-    @Deprecated('''
-    Use onChanged instead.
-    Will be removed in v5.0.0.
-    ''') ValueChanged<DateTime>? onDateSelected,
-    @Deprecated('''
-    Use value instead.
-    Will be removed in v5.0.0.
-    ''') DateTime? selectedDate,
-    @Deprecated('''
-    enabled has no effect anymore. It gets evaluated from onChanged != null.
-    Will be removed in v5.0.0.''') bool? enabled,
-    @Deprecated('''
-    Use initialPickerDateTime instead.
-    Will be removed in v5.0.0
-    ''') DateTime? initialDate,
-    @Deprecated('''
-    Uses now by default MediaQuery.of(context).alwaysUse24HourFormat.
-    Will be removed in v5.0.0.
-    ''') bool? use24hFormat,
-    @Deprecated('''
-    Use style instead.
-    Will be removed in v5.0.0.
-    ''') TextStyle? dateTextStyle,
-    @Deprecated('''
-    Has no effect anymore.
-    Will be removed in v5.0.0
-    ''') DatePickerEntryMode? initialEntryMode,
-    @Deprecated('''
-    Use materialTimePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') TimePickerEntryMode? initialTimePickerEntryMode,
   }) =>
       DateTimeField(
         key: key,
@@ -172,11 +94,10 @@ class DateTimeField extends StatefulWidget {
         firstDate: firstDate ?? DateTime(2000),
         lastDate: lastDate ?? DateTime(2001),
         onChanged: onChanged,
-        value: value ?? selectedDate,
+        value: value,
         decoration: decoration,
-        initialPickerDateTime: initialPickerDateTime ?? initialDate,
-        use24hFormat: use24hFormat,
-        style: style ?? dateTextStyle,
+        initialPickerDateTime: initialPickerDateTime,
+        style: style,
         autofocus: autofocus,
         dateFormat: dateFormat,
         padding: padding,
@@ -186,7 +107,6 @@ class DateTimeField extends StatefulWidget {
         enableFeedback: enableFeedback,
         cupertinoDatePickerOptions: cupertinoDatePickerOptions,
         materialTimePickerOptions: materialTimePickerOptions,
-        initialTimePickerEntryMode: initialTimePickerEntryMode,
       );
 
   DateTimeField._formField({
@@ -205,7 +125,6 @@ class DateTimeField extends StatefulWidget {
     DateTime? lastDate,
     DateFormat? dateFormat,
     this.hideDefaultSuffixIcon = false,
-    this.use24hFormat,
     this.cupertinoDatePickerOptions = const CupertinoDatePickerOptions(),
     this.materialDatePickerOptions = const MaterialDatePickerOptions(),
     this.materialTimePickerOptions = const MaterialTimePickerOptions(),
@@ -293,12 +212,6 @@ class DateTimeField extends StatefulWidget {
   ///   [CupertinoDatePickerMode].
   /// - Else => a [MaterialDatePicker], a [MaterialTimePicker] or both.
   final DateTimeFieldPickerMode mode;
-
-  @Deprecated('''
-  Uses now by default MediaQuery.of(context).alwaysUse24HourFormat.
-  Will be removed in v5.0.0.
-  ''')
-  final bool? use24hFormat;
 
   @override
   State<DateTimeField> createState() => _DateTimeFieldState();
@@ -596,10 +509,6 @@ class _DateTimeFieldState extends State<DateTimeField> {
   }
 
   bool get _use24HourFormat {
-    if (widget.use24hFormat != null) {
-      return widget.use24hFormat!;
-    }
-
     final DateFormat formatter = DateFormat.jm(Localizations.localeOf(context).toString());
     final DateTime now = DateTime.parse('2000-01-01 17:00:00');
     final String formattedTime = formatter.format(now);

--- a/lib/src/field.dart
+++ b/lib/src/field.dart
@@ -36,8 +36,7 @@ enum DateTimeFieldPickerMode {
   CupertinoDatePickerMode toCupertinoDatePickerMode() => switch (this) {
         DateTimeFieldPickerMode.time => CupertinoDatePickerMode.time,
         DateTimeFieldPickerMode.date => CupertinoDatePickerMode.date,
-        DateTimeFieldPickerMode.dateAndTime =>
-          CupertinoDatePickerMode.dateAndTime,
+        DateTimeFieldPickerMode.dateAndTime => CupertinoDatePickerMode.dateAndTime,
       };
 }
 
@@ -49,76 +48,26 @@ class DateTimeField extends StatefulWidget {
   DateTimeField({
     required this.onChanged,
     super.key,
-    DateTime? value,
+    this.value,
     this.onTap,
-    TextStyle? style,
+    this.style,
     this.focusNode,
     this.autofocus = false,
     this.enableFeedback,
     this.padding,
     this.hideDefaultSuffixIcon = false,
     this.decoration,
-    DateTime? initialPickerDateTime,
+    this.initialPickerDateTime,
     this.cupertinoDatePickerOptions = const CupertinoDatePickerOptions(),
-    MaterialDatePickerOptions? materialDatePickerOptions,
-    MaterialTimePickerOptions? materialTimePickerOptions,
+    this.materialDatePickerOptions = const MaterialDatePickerOptions(),
+    this.materialTimePickerOptions = const MaterialTimePickerOptions(),
     this.mode = DateTimeFieldPickerMode.dateAndTime,
     DateTime? firstDate,
     DateTime? lastDate,
     DateFormat? dateFormat,
-    this.use24hFormat,
-    @Deprecated('''
-    enabled has no effect anymore. It gets evaluated from onChanged != null.
-    Will be removed in v5.0.0.
-    ''') bool? enabled,
-    @Deprecated('''
-    Use value instead.
-    Will be removed in v5.0.0.
-    ''') DateTime? selectedDate,
-    @Deprecated('''
-    Use style instead.
-    Will be removed in v5.0.0.
-    ''') TextStyle? dateTextStyle,
-    @Deprecated('''
-    Use onChanged instead.
-    Will be removed in v5.0.0.
-    ''') ValueChanged<DateTime>? onDateSelected,
-    @Deprecated('''
-    Use materialDatePickerOptions.initialDatePickerMode instead.
-    Will be removed in v5.0.0
-    ''') DatePickerMode? initialDatePickerMode,
-    @Deprecated('''
-    Use materialDatePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') DatePickerEntryMode? initialEntryMode,
-    @Deprecated('''
-    Use initialPickerDateTime instead.
-    Will be removed in v5.0.0
-    ''') DateTime? initialDate,
-    @Deprecated('''
-    Use materialTimePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') TimePickerEntryMode? initialTimePickerEntryMode,
-  })  : assert(enabled == null || enabled == (onChanged != null),
-            'enabled got deprecated. The new behavior uses `onChanged != null`'),
-        dateFormat = dateFormat ?? mode.toDateFormat(),
-        style = style ?? dateTextStyle,
+  })  : dateFormat = dateFormat ?? mode.toDateFormat(),
         firstDate = firstDate ?? _kDefaultFirstSelectableDate,
-        lastDate = lastDate ?? _kDefaultLastSelectableDate,
-        initialPickerDateTime = initialPickerDateTime ?? initialDate,
-        value = value ?? selectedDate,
-        materialDatePickerOptions = materialDatePickerOptions ??
-            MaterialDatePickerOptions(
-              initialEntryMode:
-                  initialEntryMode ?? DatePickerEntryMode.calendar,
-              initialDatePickerMode:
-                  initialDatePickerMode ?? DatePickerMode.day,
-            ),
-        materialTimePickerOptions = materialTimePickerOptions ??
-            MaterialTimePickerOptions(
-              initialEntryMode:
-                  initialTimePickerEntryMode ?? TimePickerEntryMode.dial,
-            );
+        lastDate = lastDate ?? _kDefaultLastSelectableDate;
 
   factory DateTimeField.time({
     Key? key,
@@ -129,9 +78,8 @@ class DateTimeField extends StatefulWidget {
     DateTime? lastDate,
     DateTime? initialPickerDateTime,
     TextStyle? style,
-    CupertinoDatePickerOptions cupertinoDatePickerOptions =
-        const CupertinoDatePickerOptions(),
-    MaterialTimePickerOptions? materialTimePickerOptions,
+    CupertinoDatePickerOptions cupertinoDatePickerOptions = const CupertinoDatePickerOptions(),
+    MaterialTimePickerOptions materialTimePickerOptions = const MaterialTimePickerOptions(),
     bool autofocus = false,
     DateFormat? dateFormat,
     EdgeInsetsGeometry? padding,
@@ -139,37 +87,6 @@ class DateTimeField extends StatefulWidget {
     FocusNode? focusNode,
     bool hideDefaultSuffixIcon = false,
     bool? enableFeedback,
-    @Deprecated('''
-    Use onChanged instead.
-    Will be removed in v5.0.0.
-    ''') ValueChanged<DateTime>? onDateSelected,
-    @Deprecated('''
-    Use value instead.
-    Will be removed in v5.0.0.
-    ''') DateTime? selectedDate,
-    @Deprecated('''
-    enabled has no effect anymore. It gets evaluated from onChanged != null.
-    Will be removed in v5.0.0.''') bool? enabled,
-    @Deprecated('''
-    Use initialPickerDateTime instead.
-    Will be removed in v5.0.0
-    ''') DateTime? initialDate,
-    @Deprecated('''
-    Uses now by default MediaQuery.of(context).alwaysUse24HourFormat.
-    Will be removed in v5.0.0.
-    ''') bool? use24hFormat,
-    @Deprecated('''
-    Use style instead.
-    Will be removed in v5.0.0.
-    ''') TextStyle? dateTextStyle,
-    @Deprecated('''
-    Has no effect anymore.
-    Will be removed in v5.0.0
-    ''') DatePickerEntryMode? initialEntryMode,
-    @Deprecated('''
-    Use materialTimePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') TimePickerEntryMode? initialTimePickerEntryMode,
   }) =>
       DateTimeField(
         key: key,
@@ -177,11 +94,10 @@ class DateTimeField extends StatefulWidget {
         firstDate: firstDate ?? DateTime(2000),
         lastDate: lastDate ?? DateTime(2001),
         onChanged: onChanged,
-        value: value ?? selectedDate,
+        value: value,
         decoration: decoration,
-        initialPickerDateTime: initialPickerDateTime ?? initialDate,
-        use24hFormat: use24hFormat,
-        style: style ?? dateTextStyle,
+        initialPickerDateTime: initialPickerDateTime,
+        style: style,
         autofocus: autofocus,
         dateFormat: dateFormat,
         padding: padding,
@@ -191,7 +107,6 @@ class DateTimeField extends StatefulWidget {
         enableFeedback: enableFeedback,
         cupertinoDatePickerOptions: cupertinoDatePickerOptions,
         materialTimePickerOptions: materialTimePickerOptions,
-        initialTimePickerEntryMode: initialTimePickerEntryMode,
       );
 
   DateTimeField._formField({
@@ -210,7 +125,6 @@ class DateTimeField extends StatefulWidget {
     DateTime? lastDate,
     DateFormat? dateFormat,
     this.hideDefaultSuffixIcon = false,
-    this.use24hFormat,
     this.cupertinoDatePickerOptions = const CupertinoDatePickerOptions(),
     this.materialDatePickerOptions = const MaterialDatePickerOptions(),
     this.materialTimePickerOptions = const MaterialTimePickerOptions(),
@@ -299,12 +213,6 @@ class DateTimeField extends StatefulWidget {
   /// - Else => a [MaterialDatePicker], a [MaterialTimePicker] or both.
   final DateTimeFieldPickerMode mode;
 
-  @Deprecated('''
-  Uses now by default MediaQuery.of(context).alwaysUse24HourFormat.
-  Will be removed in v5.0.0.
-  ''')
-  final bool? use24hFormat;
-
   @override
   State<DateTimeField> createState() => _DateTimeFieldState();
 }
@@ -374,12 +282,10 @@ class _DateTimeFieldState extends State<DateTimeField> {
     final bool isDense = decoration.isDense ?? false;
 
     Widget result = MediaQuery(
-      data: MediaQuery.of(context)
-          .copyWith(alwaysUse24HourFormat: _use24HourFormat),
+      data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: _use24HourFormat),
       child: DefaultTextStyle(
-        style: _enabled
-            ? _textStyle!
-            : _textStyle!.copyWith(color: Theme.of(context).disabledColor),
+        style:
+            _enabled ? _textStyle! : _textStyle!.copyWith(color: Theme.of(context).disabledColor),
         child: ConstrainedBox(
           constraints: BoxConstraints(
             minHeight: _denseButtonHeight,
@@ -392,8 +298,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
       ),
     );
 
-    final MouseCursor effectiveMouseCursor =
-        MaterialStateProperty.resolveAs<MouseCursor>(
+    final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor>(
       MaterialStateMouseCursor.clickable,
       <MaterialState>{
         if (!_enabled) MaterialState.disabled,
@@ -495,11 +400,8 @@ class _DateTimeFieldState extends State<DateTimeField> {
       initialTime: TimeOfDay.fromDateTime(_initialPickerDateTime),
       builder: (BuildContext context, Widget? child) {
         return MediaQuery(
-          data: MediaQuery.of(context)
-              .copyWith(alwaysUse24HourFormat: _use24HourFormat),
-          child:
-              widget.materialTimePickerOptions.builder?.call(context, child) ??
-                  child!,
+          data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: _use24HourFormat),
+          child: widget.materialTimePickerOptions.builder?.call(context, child) ?? child!,
         );
       },
       initialEntryMode: widget.materialTimePickerOptions.initialEntryMode,
@@ -522,15 +424,11 @@ class _DateTimeFieldState extends State<DateTimeField> {
       lastDate: widget.lastDate,
       builder: (BuildContext context, Widget? child) {
         return MediaQuery(
-          data: MediaQuery.of(context)
-              .copyWith(alwaysUse24HourFormat: _use24HourFormat),
-          child:
-              widget.materialDatePickerOptions.builder?.call(context, child) ??
-                  child!,
+          data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: _use24HourFormat),
+          child: widget.materialDatePickerOptions.builder?.call(context, child) ?? child!,
         );
       },
-      initialDatePickerMode:
-          widget.materialDatePickerOptions.initialDatePickerMode,
+      initialDatePickerMode: widget.materialDatePickerOptions.initialDatePickerMode,
       initialEntryMode: widget.materialDatePickerOptions.initialEntryMode,
       currentDate: widget.materialDatePickerOptions.currentDate,
       locale: widget.materialDatePickerOptions.locale,
@@ -542,12 +440,9 @@ class _DateTimeFieldState extends State<DateTimeField> {
       fieldLabelText: widget.materialDatePickerOptions.fieldLabelText,
       helpText: widget.materialDatePickerOptions.helpText,
       keyboardType: widget.materialDatePickerOptions.keyboardType,
-      selectableDayPredicate:
-          widget.materialDatePickerOptions.selectableDayPredicate,
-      switchToCalendarEntryModeIcon:
-          widget.materialDatePickerOptions.switchToCalendarEntryModeIcon,
-      switchToInputEntryModeIcon:
-          widget.materialDatePickerOptions.switchToInputEntryModeIcon,
+      selectableDayPredicate: widget.materialDatePickerOptions.selectableDayPredicate,
+      switchToCalendarEntryModeIcon: widget.materialDatePickerOptions.switchToCalendarEntryModeIcon,
+      switchToInputEntryModeIcon: widget.materialDatePickerOptions.switchToInputEntryModeIcon,
       textDirection: widget.materialDatePickerOptions.textDirection,
       useRootNavigator: widget.materialDatePickerOptions.useRootNavigator,
     );
@@ -556,8 +451,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
   Future<DateTime?> _showCupertinoPicker() async {
     final DateTime initialDateTime = switch (widget.mode) {
       DateTimeFieldPickerMode.time => _initialPickerDateTime,
-      DateTimeFieldPickerMode.date =>
-        DateUtils.dateOnly(_initialPickerDateTime),
+      DateTimeFieldPickerMode.date => DateUtils.dateOnly(_initialPickerDateTime),
       DateTimeFieldPickerMode.dateAndTime => _initialPickerDateTime,
     };
 
@@ -586,9 +480,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
           mode: widget.mode,
         );
 
-        return widget.cupertinoDatePickerOptions.builder
-                ?.call(context, modal) ??
-            modal;
+        return widget.cupertinoDatePickerOptions.builder?.call(context, modal) ?? modal;
       },
     );
   }
@@ -617,12 +509,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
   }
 
   bool get _use24HourFormat {
-    if (widget.use24hFormat != null) {
-      return widget.use24hFormat!;
-    }
-
-    final DateFormat formatter =
-        DateFormat.jm(Localizations.localeOf(context).toString());
+    final DateFormat formatter = DateFormat.jm(Localizations.localeOf(context).toString());
     final DateTime now = DateTime.parse('2000-01-01 17:00:00');
     final String formattedTime = formatter.format(now);
     final bool localeBasedUse24HourFormat = !formattedTime.contains('PM');
@@ -642,17 +529,15 @@ class _DateTimeFieldState extends State<DateTimeField> {
   // but don't make it smaller than the text that it contains. Similarly, we don't
   // reduce the height of the button so much that its icon would be clipped.
   double get _denseButtonHeight {
-    final double fontSize = _textStyle!.fontSize ??
-        Theme.of(context).textTheme.titleMedium!.fontSize!;
-    final double scaledFontSize =
-        MediaQuery.textScalerOf(context).scale(fontSize);
+    final double fontSize =
+        _textStyle!.fontSize ?? Theme.of(context).textTheme.titleMedium!.fontSize!;
+    final double scaledFontSize = MediaQuery.textScalerOf(context).scale(fontSize);
     return math.max(scaledFontSize, _kDenseButtonHeight);
   }
 
   bool get _enabled => widget.onChanged != null;
 
-  TextStyle? get _textStyle =>
-      widget.style ?? Theme.of(context).textTheme.titleMedium;
+  TextStyle? get _textStyle => widget.style ?? Theme.of(context).textTheme.titleMedium;
 
   FocusNode? get _focusNode => widget.focusNode ?? _internalNode;
 
@@ -685,12 +570,10 @@ class _CupertinoDatePickerModalSheet extends StatefulWidget {
   final DateTime lastDate;
 
   @override
-  State<_CupertinoDatePickerModalSheet> createState() =>
-      _CupertinoDatePickerModalSheetState();
+  State<_CupertinoDatePickerModalSheet> createState() => _CupertinoDatePickerModalSheetState();
 }
 
-class _CupertinoDatePickerModalSheetState
-    extends State<_CupertinoDatePickerModalSheet> {
+class _CupertinoDatePickerModalSheetState extends State<_CupertinoDatePickerModalSheet> {
   DateTime? _pickedDate;
 
   late Map<Type, Action<Intent>> _cancelActionMap;
@@ -740,8 +623,7 @@ class _CupertinoDatePickerModalSheetState
             ),
             brightness: Theme.of(context).brightness,
             middle: Text(
-              widget.options.modalTitleText ??
-                  MaterialLocalizations.of(context).dateInputLabel,
+              widget.options.modalTitleText ?? MaterialLocalizations.of(context).dateInputLabel,
               style: widget.options.style.modalTitle ??
                   CupertinoTheme.of(context).textTheme.navTitleTextStyle,
             ),
@@ -751,8 +633,7 @@ class _CupertinoDatePickerModalSheetState
                 padding: EdgeInsets.zero,
                 child: Text(
                   widget.options.cancelText ??
-                      CupertinoLocalizations.of(context)
-                          .modalBarrierDismissLabel,
+                      CupertinoLocalizations.of(context).modalBarrierDismissLabel,
                   style: widget.options.style.cancelButton,
                 ),
                 onPressed: _cancel,
@@ -763,8 +644,7 @@ class _CupertinoDatePickerModalSheetState
               child: CupertinoButton(
                 padding: EdgeInsets.zero,
                 child: Text(
-                  widget.options.saveText ??
-                      MaterialLocalizations.of(context).saveButtonLabel,
+                  widget.options.saveText ?? MaterialLocalizations.of(context).saveButtonLabel,
                   style: widget.options.style.saveButton,
                 ),
                 onPressed: _save,

--- a/lib/src/form_field.dart
+++ b/lib/src/form_field.dart
@@ -29,47 +29,15 @@ class DateTimeFormField extends FormField<DateTime> {
     bool hideDefaultSuffixIcon = false,
     DateTime? initialPickerDateTime,
     CupertinoDatePickerOptions cupertinoDatePickerOptions = const CupertinoDatePickerOptions(),
-    MaterialDatePickerOptions? materialDatePickerOptions,
-    MaterialTimePickerOptions? materialTimePickerOptions,
+    MaterialDatePickerOptions materialDatePickerOptions = const MaterialDatePickerOptions(),
+    MaterialTimePickerOptions materialTimePickerOptions = const MaterialTimePickerOptions(),
     InputDecoration? decoration,
     DateFormat? dateFormat,
     DateTime? firstDate,
     DateTime? lastDate,
     DateTimeFieldPickerMode mode = DateTimeFieldPickerMode.dateAndTime,
-    @Deprecated('''
-    enabled has no effect anymore. It gets evaluated from onChanged != null.
-    Will be removed in v5.0.0.
-    ''') bool? enabled,
-    @Deprecated('''
-    Use style instead.
-    Will be removed in v5.0.0.
-    ''') TextStyle? dateTextStyle,
-    @Deprecated('''
-    Use onChanged instead.
-    Will be removed in v5.0.0.
-    ''') ValueChanged<DateTime>? onDateSelected,
-    @Deprecated('''
-    Use materialDatePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') DatePickerMode? initialDatePickerMode,
-    @Deprecated('''
-    Use materialDatePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') DatePickerEntryMode? initialEntryMode,
-    @Deprecated('''
-    Use initialPickerDateTime instead.
-    Will be removed in v5.0.0
-    ''') DateTime? initialDate,
-    @Deprecated('''
-    Use materialTimePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') TimePickerEntryMode? initialTimePickerEntryMode,
-    @Deprecated('''
-    Uses now by default MediaQuery.of(context).alwaysUse24HourFormat.
-    Will be removed in v5.0.0.
-    ''') bool? use24hFormat,
   }) : super(
-          enabled: enabled ?? decoration?.enabled ?? true, // @Kept
+          enabled: decoration?.enabled ?? true,
           builder: (FormFieldState<DateTime> field) {
             final _DateTimeFormFieldState state = field as _DateTimeFormFieldState;
 
@@ -105,22 +73,14 @@ class DateTimeFormField extends FormField<DateTime> {
                     decoration: decorationArg,
                     padding: padding,
                     firstDate: firstDate,
-                    initialPickerDateTime: initialPickerDateTime ?? initialDate,
+                    initialPickerDateTime: initialPickerDateTime,
                     lastDate: lastDate,
                     dateFormat: dateFormat,
-                    use24hFormat: use24hFormat,
                     mode: mode,
                     hideDefaultSuffixIcon: hideDefaultSuffixIcon,
                     cupertinoDatePickerOptions: cupertinoDatePickerOptions,
-                    materialDatePickerOptions: materialDatePickerOptions ??
-                        MaterialDatePickerOptions(
-                          initialEntryMode: initialEntryMode ?? DatePickerEntryMode.calendar,
-                          initialDatePickerMode: initialDatePickerMode ?? DatePickerMode.day,
-                        ),
-                    materialTimePickerOptions: materialTimePickerOptions ??
-                        MaterialTimePickerOptions(
-                          initialEntryMode: initialTimePickerEntryMode ?? TimePickerEntryMode.dial,
-                        ),
+                    materialDatePickerOptions: materialDatePickerOptions,
+                    materialTimePickerOptions: materialTimePickerOptions,
                   );
                 },
               ),

--- a/lib/src/form_field.dart
+++ b/lib/src/form_field.dart
@@ -28,58 +28,23 @@ class DateTimeFormField extends FormField<DateTime> {
     EdgeInsetsGeometry? padding,
     bool hideDefaultSuffixIcon = false,
     DateTime? initialPickerDateTime,
-    CupertinoDatePickerOptions cupertinoDatePickerOptions =
-        const CupertinoDatePickerOptions(),
-    MaterialDatePickerOptions? materialDatePickerOptions,
-    MaterialTimePickerOptions? materialTimePickerOptions,
+    CupertinoDatePickerOptions cupertinoDatePickerOptions = const CupertinoDatePickerOptions(),
+    MaterialDatePickerOptions materialDatePickerOptions = const MaterialDatePickerOptions(),
+    MaterialTimePickerOptions materialTimePickerOptions = const MaterialTimePickerOptions(),
     InputDecoration? decoration,
     DateFormat? dateFormat,
     DateTime? firstDate,
     DateTime? lastDate,
     DateTimeFieldPickerMode mode = DateTimeFieldPickerMode.dateAndTime,
-    @Deprecated('''
-    enabled has no effect anymore. It gets evaluated from onChanged != null.
-    Will be removed in v5.0.0.
-    ''') bool? enabled,
-    @Deprecated('''
-    Use style instead.
-    Will be removed in v5.0.0.
-    ''') TextStyle? dateTextStyle,
-    @Deprecated('''
-    Use onChanged instead.
-    Will be removed in v5.0.0.
-    ''') ValueChanged<DateTime>? onDateSelected,
-    @Deprecated('''
-    Use materialDatePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') DatePickerMode? initialDatePickerMode,
-    @Deprecated('''
-    Use materialDatePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') DatePickerEntryMode? initialEntryMode,
-    @Deprecated('''
-    Use initialPickerDateTime instead.
-    Will be removed in v5.0.0
-    ''') DateTime? initialDate,
-    @Deprecated('''
-    Use materialTimePickerOptions.initialEntryMode instead.
-    Will be removed in v5.0.0
-    ''') TimePickerEntryMode? initialTimePickerEntryMode,
-    @Deprecated('''
-    Uses now by default MediaQuery.of(context).alwaysUse24HourFormat.
-    Will be removed in v5.0.0.
-    ''') bool? use24hFormat,
   }) : super(
-          enabled: enabled ?? decoration?.enabled ?? true, // @Kept
+          enabled: decoration?.enabled ?? true,
           builder: (FormFieldState<DateTime> field) {
-            final _DateTimeFormFieldState state =
-                field as _DateTimeFormFieldState;
+            final _DateTimeFormFieldState state = field as _DateTimeFormFieldState;
 
             final bool isEmpty = state.value == null;
 
             InputDecoration decorationArg =
-                (decoration ?? const InputDecoration())
-                    .copyWith(errorText: field.errorText);
+                (decoration ?? const InputDecoration()).copyWith(errorText: field.errorText);
 
             if (canClear && !isEmpty) {
               decorationArg = decorationArg.copyWith(
@@ -108,25 +73,14 @@ class DateTimeFormField extends FormField<DateTime> {
                     decoration: decorationArg,
                     padding: padding,
                     firstDate: firstDate,
-                    initialPickerDateTime: initialPickerDateTime ?? initialDate,
+                    initialPickerDateTime: initialPickerDateTime,
                     lastDate: lastDate,
                     dateFormat: dateFormat,
-                    use24hFormat: use24hFormat,
                     mode: mode,
                     hideDefaultSuffixIcon: hideDefaultSuffixIcon,
                     cupertinoDatePickerOptions: cupertinoDatePickerOptions,
-                    materialDatePickerOptions: materialDatePickerOptions ??
-                        MaterialDatePickerOptions(
-                          initialEntryMode:
-                              initialEntryMode ?? DatePickerEntryMode.calendar,
-                          initialDatePickerMode:
-                              initialDatePickerMode ?? DatePickerMode.day,
-                        ),
-                    materialTimePickerOptions: materialTimePickerOptions ??
-                        MaterialTimePickerOptions(
-                          initialEntryMode: initialTimePickerEntryMode ??
-                              TimePickerEntryMode.dial,
-                        ),
+                    materialDatePickerOptions: materialDatePickerOptions,
+                    materialTimePickerOptions: materialTimePickerOptions,
                   );
                 },
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: date_field
 description: A widget in the form of a field that lets people choose a date, a time or both.
-version: 4.0.0
+version: 5.0.0
 homepage: 'https://github.com/GaspardMerten/date_field'
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: date_field
 description: A widget in the form of a field that lets people choose a date, a time or both.
-version: 4.1.0
+version: 5.0.0
 homepage: 'https://github.com/GaspardMerten/date_field'
 
 environment:


### PR DESCRIPTION
This removes the deprecated parameters from verison `4.0.0`.  We should give people time to migrate first and merge this in a month or so.