### PR TITLE
fix clear button disappearing on rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+- Fix clear button disappearing on rebuild 
+
 # 4.0.0
 
 - Removing override of MediaQuery.alwaysUse24HourFormat from the time picker dialog

--- a/lib/src/form_field.dart
+++ b/lib/src/form_field.dart
@@ -78,7 +78,7 @@ class DateTimeFormField extends FormField<DateTime> {
             InputDecoration decorationArg =
                 (decoration ?? const InputDecoration()).copyWith(errorText: field.errorText);
 
-            if (canClear && !isEmpty && state.value != initialValue) {
+            if (canClear && !isEmpty) {
               decorationArg = decorationArg.copyWith(
                 suffixIcon: IconButton(
                   icon: Icon(clearIconData),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: date_field
 description: A widget in the form of a field that lets people choose a date, a time or both.
-version: 4.0.0
+version: 4.1.0
 homepage: 'https://github.com/GaspardMerten/date_field'
 
 environment:


### PR DESCRIPTION
When providing the current selected value as initialValue, the clear button disappears on rebuild. This was intendet to not show the clear button when the initial value was selected. But I realized this produces unexpected behaviour of the widget. After the change the user can still implement this himself by changing `canClear` from outside