### PR TITLE
Fix empty value to resolve hintText layout issue

### DIFF
--- a/lib/src/field.dart
+++ b/lib/src/field.dart
@@ -298,7 +298,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
           ),
           child: widget.value != null
               ? Text(widget.dateFormat.format(widget.value!))
-              : const SizedBox.shrink(),
+              : const Text(''),
         ),
       ),
     );


### PR DESCRIPTION
Changed how empty values are displayed.

Currently, if no date is given, a `SizedBox` is rendered. Instead, a `Text` with an empty string should be rendered.
The difference is that an empty `SizedBox` has a height of 0 whereas the empty `Text` height corresponds to the line height of the text. This is a better suited placeholder as the height will always stay the same if there is or isn't a value present.

This fixes issues with the display of e.g. `hintText` when no label is given as it would otherwise result in different field sizes or when using outlined fields, the hintText would be misplaced.

Before:
![Screenshot 2024-04-26 at 15 42 07](https://github.com/GaspardMerten/date_field/assets/3381449/d49fa095-e9cd-4752-9aa2-6502545eba10)

After:
![Screenshot 2024-04-26 at 15 43 02](https://github.com/GaspardMerten/date_field/assets/3381449/05410f08-1189-46e0-9844-b99f6e0291be)

