### PR TITLE
platform assertions according to platform

### DIFF
--- a/lib/src/widgets/field.dart
+++ b/lib/src/widgets/field.dart
@@ -274,12 +274,21 @@ class _DateTimeFieldState extends State<DateTimeField> {
     }
   }
 
+  void _assertPickerPlatform() {
+    if (widget.pickerPlatform != DateTimeFieldPickerPlatform.material) {
+      assert(debugCheckHasCupertinoLocalizations(context));
+    }
+
+    if (widget.pickerPlatform != DateTimeFieldPickerPlatform.cupertino) {
+      assert(debugCheckHasMaterialLocalizations(context));
+      assert(debugCheckHasMaterial(context));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    assert(debugCheckHasMaterial(context));
-    assert(debugCheckHasMaterialLocalizations(context));
-    assert(debugCheckHasCupertinoLocalizations(context));
-
+    _assertPickerPlatform();
+    
     InputDecoration decoration = widget.decoration ?? const InputDecoration();
 
     decoration = decoration.applyDefaults(


### PR DESCRIPTION
The objective of this PR is to allow using the `DateTimeField` without forcing both Material and Cupertino delegates.
currently, the assertions in `_DateTimeFieldState.build` are making sure both have defined delegates even when choosing a specific `pickerPlatform`.

I've moved the assertions into a separate method, where each is asserted conditionally.