### PR TITLE
Fixed inkwell enabled feedback nullable bool

### DIFF
--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -227,7 +227,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return true
+  }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }
 }

--- a/lib/src/widgets/field.dart
+++ b/lib/src/widgets/field.dart
@@ -274,7 +274,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
     }
   }
 
-  bool debugCheckLocalizationsForPlatformAvailable(BuildContext context){
+  bool debugCheckLocalizationsForPlatformAvailable(BuildContext context) {
     assert(() {
       switch (widget.pickerPlatform) {
         case DateTimeFieldPickerPlatform.material:
@@ -372,7 +372,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
           focusNode: _focusNode,
           autofocus: widget.autofocus,
           focusColor: decoration.focusColor,
-          enableFeedback: widget.enableFeedback,
+          enableFeedback: widget.enableFeedback ?? true,
           child: widget.padding == null
               ? result
               : Padding(


### PR DESCRIPTION
In Flutter 3.27.0 the `enableFeedback` property on InkWell is no longer a of type `bool?`. This pr handles the enableFeedback `bool?` value.

Flutter also upgraded the Mac Project