### PR TITLE
Fixing issue #89

### DIFF
--- a/lib/src/widgets/adaptive_dialog.dart
+++ b/lib/src/widgets/adaptive_dialog.dart
@@ -32,6 +32,17 @@ DateTime _getInitialDate(
   return now;
 }
 
+/// [TimeOfDay] Extensions
+extension on TimeOfDay {
+  bool isBefore(TimeOfDay other) {
+    return (hour * 60 + minute) < (other.hour * 60 + other.minute);
+  }
+
+  bool isAfter(TimeOfDay other) {
+    return (hour * 60 + minute) > (other.hour * 60 + other.minute);
+  }
+}
+
 /// A function that returns the initial time to be displayed by the picker.
 /// If [initialPickerDateTime] is not provided, the function returns the current
 /// time if it is within the selectable time range. Otherwise, it returns the


### PR DESCRIPTION
fix error

```bash
[+1099 ms] [+2733 ms] ../../.pub-cache/hosted/mirrors.tuna.tsinghua.edu.cn%2547dart-pub%2547/date_field-5.3.4/lib/src/widgets/adaptive_dialog.dart:47:11: Error: The method 'isBefore' isn't
defined for the class 'TimeOfDay'.
[        ] [        ]  - 'TimeOfDay' is from 'package:flutter/src/material/time.dart' ('../flutter/packages/flutter/lib/src/material/time.dart').
[        ] [        ] Try correcting the name to the name of an existing method, or defining a method named 'isBefore'.
[        ] [        ]   if (now.isBefore(TimeOfDay.fromDateTime(firstDate))) {
[        ] [        ]           ^^^^^^^^
[        ] [        ] ../../.pub-cache/hosted/mirrors.tuna.tsinghua.edu.cn%2547dart-pub%2547/date_field-5.3.4/lib/src/widgets/adaptive_dialog.dart:51:11: Error: The method 'isAfter' isn't
defined for the class 'TimeOfDay'.
[        ] [        ]  - 'TimeOfDay' is from 'package:flutter/src/material/time.dart' ('../flutter/packages/flutter/lib/src/material/time.dart').
[        ] [        ] Try correcting the name to the name of an existing method, or defining a method named 'isAfter'.
[        ] [        ]   if (now.isAfter(TimeOfDay.fromDateTime(lastDate))) {
[        ] [        ]
```