### PR TITLE
Set default value for enableFeedback in DateTimeField widget

### DIFF
--- a/lib/src/widgets/field.dart
+++ b/lib/src/widgets/field.dart
@@ -364,7 +364,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
           focusNode: _focusNode,
           autofocus: widget.autofocus,
           focusColor: decoration.focusColor,
-          enableFeedback: widget.enableFeedback,
+          enableFeedback: widget.enableFeedback ?? true,
           child: widget.padding == null
               ? result
               : Padding(


### PR DESCRIPTION

Fixed nullable issue
```
../../../AppData/Local/Pub/Cache/hosted/pub.dev/date_field-6.0.0/lib/src/widgets/field.dart:367:34: Error: The argument type 'bool?' can't be assigned to the parameter type 'bool' because 'bool?' is nullable and 'bool' isn't.
          enableFeedback: widget.enableFeedback,
```