### PR TITLE
fix: Datepicker always using now

### DIFF
--- a/lib/src/widgets/field.dart
+++ b/lib/src/widgets/field.dart
@@ -414,6 +414,7 @@ class _DateTimeFieldState extends State<DateTimeField> {
       materialTimePickerOptions: widget.materialTimePickerOptions,
       firstDate: widget.firstDate,
       lastDate: widget.lastDate,
+      initialPickerDateTime: widget.value ?? widget.initialPickerDateTime,
     );
 
     if (mounted) {


### PR DESCRIPTION
  * use current value of field to initialize picker
  * if current value is null use initialPickerDateTime
  * clean unit test impossible (cannot inject showAdaptiveDateTimePicker)